### PR TITLE
Migrate Part6 from .NET Core 3.1 to 5.0

### DIFF
--- a/Part6/FileUpload/FileUpload.csproj
+++ b/Part6/FileUpload/FileUpload.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Migrate Part6 project to 5.0 and all packages in project. Project compiles successfully.